### PR TITLE
updates to fix issue when running on awx control node.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+## editor/IDE
+.idea/

--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ options:
     key_file:
         description:
             - Specify an optional private key file path, on the target host, to use for the checkout.
+    executable:
+        description:
+            - Path to git executable to use. If not supplied,
+              the normal mechanism for resolving binary paths will be used.
+        version_added: "1.4"
     remote:
         description:
             - Local system alias for git remote PUSH and PULL repository operations.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,22 @@ options:
             - Git repo URL.
         required: True
         type: str
+    accept_hostkey:
+        description:
+            - If C(yes), ensure that "-o StrictHostKeyChecking=no" is
+              present as an ssh option.
+        type: bool
+        default: 'no'
+    ssh_opts:
+        description:
+            - Creates a wrapper script and exports the path as GIT_SSH
+              which git then automatically uses to override ssh arguments.
+              An example value could be "-o StrictHostKeyChecking=no"
+              (although this particular option is better set via
+              C(accept_hostkey)).
+    key_file:
+        description:
+            - Specify an optional private key file path, on the target host, to use for the checkout.
     remote:
         description:
             - Local system alias for git remote PUSH and PULL repository operations.

--- a/README.md
+++ b/README.md
@@ -73,22 +73,30 @@ options:
             - Git repo URL.
         required: True
         type: str
-    accept_hostkey:
+    ssh_params:
         description:
-            - If C(yes), ensure that "-o StrictHostKeyChecking=no" is
-              present as an ssh option.
-        type: bool
-        default: 'no'
-    ssh_opts:
-        description:
-            - Creates a wrapper script and exports the path as GIT_SSH
-              which git then automatically uses to override ssh arguments.
-              An example value could be "-o StrictHostKeyChecking=no"
-              (although this particular option is better set via
-              C(accept_hostkey)).
-    key_file:
-        description:
-            - Specify an optional private key file path, on the target host, to use for the checkout.
+            - Dictionary containing SSH parameters.
+        type: dict
+        default: None
+        options:
+            key_file:
+                description:
+                    - Specify an optional private key file path, on the target host, to use for the checkout.
+            accept_hostkey:
+                description:
+                    - If C(yes), ensure that "-o StrictHostKeyChecking=no" is
+                      present as an ssh option.
+                type: bool
+                default: 'no'
+            ssh_opts:
+                description:
+                    - Creates a wrapper script and exports the path as GIT_SSH
+                      which git then automatically uses to override ssh arguments.
+                      An example value could be "-o StrictHostKeyChecking=no"
+                      (although this particular option is better set via
+                      C(accept_hostkey)).
+                type: str
+                default: None
     executable:
         description:
             - Path to git executable to use. If not supplied,

--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ options:
     user_name: lvrfrc87
     user_email: lvrfrc87@gmail.com
 
+- name: SSH with private key | add file1.
+  git_acp:
+    path: /Users/git/git_acp
+    branch: master
+    comment: Add file1.
+    add: [ file1  ]
+    remote: dev_test
+    mode: ssh
+    url: "git@gitlab.com:networkAutomation/git_test_module.git"
+    ssh_params:
+      accept_newhostkey: true
+      key_file: '{{ lookup('env', 'HOME') }}/.ssh/id_rsa'
+      ssh_opts: '-o UserKnownHostsFile={{ remote_tmp_dir }}/known_hosts'
+
 - name: LOCAL | push on local repo.
   git_acp:
     path: "~/test_directory/repo"

--- a/ansible_collections/lvrfrc87/git_acp/plugins/module_utils/git_actions.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/module_utils/git_actions.py
@@ -17,11 +17,23 @@ class Git:
         self.url = self.module.params['url']
         self.path = self.module.params['path']
         self.git_path = self.module.params['executable'] or self.module.get_bin_path('git', True)
-        self.key_file = self.module.params['key_file']
-        self.ssh_opts = self.module.params['ssh_opts']
+
+        ssh_params = self.module.params['ssh_params']
+
+        if ssh_params:
+            self.ssh_key_file = ssh_params['key_file']
+            self.ssh_opts = ssh_params['ssh_opts']
+            self.ssh_accept_hostkey = ssh_params['accept_hostkey']
+
+            if self.ssh_accept_hostkey:
+                if self.ssh_opts is not None:
+                    if "-o StrictHostKeyChecking=no" not in self.ssh_opts:
+                        self.ssh_opts += " -o StrictHostKeyChecking=no"
+                else:
+                    self.ssh_opts = "-o StrictHostKeyChecking=no"
 
         self.ssh_wrapper = self.write_ssh_wrapper(module.tmpdir)
-        self.set_git_ssh(self.ssh_wrapper, self.key_file, self.ssh_opts)
+        self.set_git_ssh(self.ssh_wrapper, self.ssh_key_file, self.ssh_opts)
         module.add_cleanup_file(path=self.ssh_wrapper)
 
     ## ref: https://github.com/ansible/ansible/blob/05b90ab69a3b023aa44b812c636bb2c48e30108e/lib/ansible/modules/git.py#L368

--- a/ansible_collections/lvrfrc87/git_acp/plugins/module_utils/git_actions.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/module_utils/git_actions.py
@@ -13,7 +13,6 @@ class Git:
 
     def __init__(self, module):
         self.module = module
-        self.git_path = git_path
 
         self.url = self.module.params['url']
         self.path = self.module.params['path']

--- a/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
@@ -65,6 +65,22 @@ options:
             - Git repo URL.
         required: True
         type: str
+    accept_hostkey:
+        description:
+            - If C(yes), ensure that "-o StrictHostKeyChecking=no" is
+              present as an ssh option.
+        type: bool
+        default: 'no'
+    ssh_opts:
+        description:
+            - Creates a wrapper script and exports the path as GIT_SSH
+              which git then automatically uses to override ssh arguments.
+              An example value could be "-o StrictHostKeyChecking=no"
+              (although this particular option is better set via
+              C(accept_hostkey)).
+    key_file:
+        description:
+            - Specify an optional private key file path, on the target host, to use for the checkout.
     remote:
         description:
             - Local system alias for git remote PUSH and PULL repository operations.

--- a/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
@@ -148,7 +148,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.lvrfrc87.git_acp.plugins.module_utils.git_actions import Git
 from ansible_collections.lvrfrc87.git_acp.plugins.module_utils.git_configuration import GitConfiguration
 
-
 def main():
     """
     Code entrypoint.
@@ -234,7 +233,7 @@ def main():
 
     result = dict(changed=False)
 
-    git = Git(module, git_path, key_file, ssh_opts)
+    git = Git(module)
 
     if user_name and user_email:
         result.update(GitConfiguration(module).user_config())

--- a/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
@@ -81,6 +81,11 @@ options:
     key_file:
         description:
             - Specify an optional private key file path, on the target host, to use for the checkout.
+    executable:
+        description:
+            - Path to git executable to use. If not supplied,
+              the normal mechanism for resolving binary paths will be used.
+        version_added: "1.4"
     remote:
         description:
             - Local system alias for git remote PUSH and PULL repository operations.

--- a/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
@@ -65,22 +65,30 @@ options:
             - Git repo URL.
         required: True
         type: str
-    accept_hostkey:
+    ssh_params:
         description:
-            - If C(yes), ensure that "-o StrictHostKeyChecking=no" is
-              present as an ssh option.
-        type: bool
-        default: 'no'
-    ssh_opts:
-        description:
-            - Creates a wrapper script and exports the path as GIT_SSH
-              which git then automatically uses to override ssh arguments.
-              An example value could be "-o StrictHostKeyChecking=no"
-              (although this particular option is better set via
-              C(accept_hostkey)).
-    key_file:
-        description:
-            - Specify an optional private key file path, on the target host, to use for the checkout.
+            - Dictionary containing SSH parameters.
+        type: dict
+        default: None
+        options:
+            key_file:
+                description:
+                    - Specify an optional private key file path, on the target host, to use for the checkout.
+            accept_hostkey:
+                description:
+                    - If C(yes), ensure that "-o StrictHostKeyChecking=no" is
+                      present as an ssh option.
+                type: bool
+                default: 'no'
+            ssh_opts:
+                description:
+                    - Creates a wrapper script and exports the path as GIT_SSH
+                      which git then automatically uses to override ssh arguments.
+                      An example value could be "-o StrictHostKeyChecking=no"
+                      (although this particular option is better set via
+                      C(accept_hostkey)).
+                type: str
+                default: None
     executable:
         description:
             - Path to git executable to use. If not supplied,
@@ -165,21 +173,19 @@ def main():
     """
     argument_spec = dict(
         path=dict(required=True, type='path'),
-        accept_hostkey=dict(default='no', type='bool'),
-        ssh_opts=dict(default=None, required=False),
-        key_file=dict(default=None, type='path', required=False),
         executable=dict(default=None, type='path'),
         comment=dict(required=True),
         add=dict(type='list', elements='str', default=['.']),
         user=dict(),
         token=dict(no_log=True),
+        ssh_params=dict(default=None, type='dict', required=False),
         branch=dict(default='main'),
-        push_option=dict(),
+        push_option=dict(default=None, type='str'),
         mode=dict(choices=['ssh', 'https', 'local'], default='ssh'),
         url=dict(required=True),
         remote=dict(default='origin'),
         user_name=dict(),
-        user_email=dict(),
+        user_email=dict()
     )
 
     required_if = [
@@ -201,16 +207,6 @@ def main():
     mode = module.params.get('mode')
     user_name = module.params.get('user_name')
     user_email = module.params.get('user_email')
-    git_path = module.params['executable'] or module.get_bin_path('git', True)
-    key_file = module.params['key_file']
-    ssh_opts = module.params['ssh_opts']
-
-    if module.params['accept_hostkey']:
-        if ssh_opts is not None:
-            if "-o StrictHostKeyChecking=no" not in ssh_opts:
-                ssh_opts += " -o StrictHostKeyChecking=no"
-        else:
-            ssh_opts = "-o StrictHostKeyChecking=no"
 
     # We screenscrape a huge amount of git commands so use C locale anytime we
     # call run_command()

--- a/ansible_collections/lvrfrc87/git_acp/tests/integration/integration_config.yml
+++ b/ansible_collections/lvrfrc87/git_acp/tests/integration/integration_config.yml
@@ -2,3 +2,12 @@
 user: "Federico87"
 token: "glpat-byFwqxbb3jEf339bAFLS"
 working_dir: "$HOME/git_acp_test/"
+
+ssh_private_key: |
+  -----BEGIN RSA PRIVATE KEY-----
+  MIIEpAIBAAKCAQEAzF9HT3L6IiyEd6nb/hVyxP8omtUWIGtvEwZHMu+tsvyOXYDb
+  NYSja/ZQhpVo9PDIoms2/wVEuzg/T28VnOEiuATsHap/yzABInttyWzJYQlUsBJZ
+  fFP6I1tTZtDq3zpyugiI5H/JV7ExtIyfAwu0BsxgC3kCVKSzeKU761pNnSeuoxjh
+  ...
+  tF5wv2frH/QhUABPFn4ihFBsdyXRnR5+wzP3rRB77Cp+JaFDr6hxBA==
+  -----END RSA PRIVATE KEY-----

--- a/ansible_collections/lvrfrc87/git_acp/tests/integration/integration_config.yml
+++ b/ansible_collections/lvrfrc87/git_acp/tests/integration/integration_config.yml
@@ -3,11 +3,4 @@ user: "Federico87"
 token: "glpat-byFwqxbb3jEf339bAFLS"
 working_dir: "$HOME/git_acp_test/"
 
-ssh_private_key: |
-  -----BEGIN RSA PRIVATE KEY-----
-  MIIEpAIBAAKCAQEAzF9HT3L6IiyEd6nb/hVyxP8omtUWIGtvEwZHMu+tsvyOXYDb
-  NYSja/ZQhpVo9PDIoms2/wVEuzg/T28VnOEiuATsHap/yzABInttyWzJYQlUsBJZ
-  fFP6I1tTZtDq3zpyugiI5H/JV7ExtIyfAwu0BsxgC3kCVKSzeKU761pNnSeuoxjh
-  ...
-  tF5wv2frH/QhUABPFn4ihFBsdyXRnR5+wzP3rRB77Cp+JaFDr6hxBA==
-  -----END RSA PRIVATE KEY-----
+github_ssh_private_key: "{{ lookup('env', 'HOME') }}/.ssh/id_rsa"

--- a/ansible_collections/lvrfrc87/git_acp/tests/integration/targets/git_acp/tasks/main.yml
+++ b/ansible_collections/lvrfrc87/git_acp/tests/integration/targets/git_acp/tasks/main.yml
@@ -4,7 +4,7 @@
     repo: "https://{{ user }}:{{ token }}@gitlab.com/networkAutomation/git_test_module.git"
     dest: "{{ working_dir }}"
 
-- name: 10005 - SETUP | https loca repo ahead.
+- name: 10005 - SETUP | https local repo ahead.
   register: result
   git_acp:
     user: "{{ user }}"
@@ -175,7 +175,131 @@
 - name: 10075 - SETUP | debug default remote set.
   shell: git -C "{{ working_dir }}" remote get-url --all origin
   register: remote
-- debug: var=origin
+- debug: var=remote
+
+
+
+##############################################
+##
+## Test using SSH using private key
+##
+##############################################
+- name: 10160 - SSH Host Key Test Setup | create temporary directory
+  tempfile:
+    state: directory
+    suffix: .test
+  register: remote_tmp_dir
+  notify:
+    - delete temporary directory
+
+- name: 10161 - SSH Host Key Test Setup | Record temporary directory
+  set_fact:
+    remote_tmp_dir: "{{ remote_tmp_dir.path }}"
+    cacheable: "{{ setup_remote_tmp_dir_cache_path | bool }}"
+
+
+- name: 10165 - MISSING-HOSTKEY | check accept_newhostkey support
+  shell: ssh -o StrictHostKeyChecking=accept-new -V
+  register: ssh_supports_accept_newhostkey
+  ignore_errors: true
+
+- name: 10166 - MISSING-HOSTKEY | missing hostkey tests
+  when: ssh_supports_accept_newhostkey.rc != 0
+  block:
+
+    - name: 10167 - MISSING-HOSTKEY | accept_newhostkey when ssh does not support the option
+      git_acp:
+        url: "git@gitlab.com:networkAutomation/git_test_module.git"
+        path: "{{ working_dir }}"
+        branch: master
+        comment: Add .
+        mode: ssh
+        ssh_params:
+          accept_newhostkey: true
+          key_file: '{{ github_ssh_private_key }}'
+          ssh_opts: '-o UserKnownHostsFile={{ remote_tmp_dir }}/known_hosts'
+      register: git_result
+      ignore_errors: true
+
+    - assert:
+        that:
+          - git_result is failed
+          - git_result.warnings is search("does not support")
+
+
+- name: 10168 - MISSING-HOSTKEY | push ssh://git@github.com repo without accept_newhostkey (expected fail)
+  git_acp:
+    url: "git@gitlab.com:networkAutomation/git_test_module.git"
+    path: "{{ working_dir }}"
+    branch: master
+    comment: Add .
+    mode: ssh
+    ssh_params:
+      ssh_opts: '-o UserKnownHostsFile={{ remote_tmp_dir }}/known_hosts'
+  register: git_result
+  ignore_errors: true
+
+- assert:
+    that:
+      - git_result is failed
+
+- name: 10169 - HOSTKEY TESTS | Validate ssh with private host key
+  when: github_ssh_private_key is defined and ssh_supports_accept_newhostkey.rc == 0
+  block:
+    - name: 10170 - HOSTKEY TESTS | checkout git@github.com repo with accept_newhostkey (expected pass)
+      git_acp:
+        path: "{{ working_dir }}"
+        branch: master
+        comment: Add file1.
+        add: [ "{{ file1 }}" ]
+        mode: ssh
+        url: "git@gitlab.com:networkAutomation/git_test_module.git"
+        ssh_params:
+          accept_newhostkey: true
+          key_file: '{{ github_ssh_private_key }}'
+          ssh_opts: '-o UserKnownHostsFile={{ remote_tmp_dir }}/known_hosts'
+      register: git_result
+
+    - assert:
+        that:
+          - git_result is changed
+
+    - name: 10172 - HOSTKEY TESTS | checkout ssh://git@github.com repo with accept_newhostkey (expected pass)
+      git_acp:
+        path: "{{ working_dir }}"
+        branch: master
+        comment: Add file1.
+        add: [ "{{ file1 }}" ]
+        mode: ssh
+        url: "git@gitlab.com:networkAutomation/git_test_module.git"
+        ssh_params:
+          accept_newhostkey: false # should already have been accepted
+          key_file: '{{ github_ssh_private_key }}'
+          ssh_opts: '-o UserKnownHostsFile={{ remote_tmp_dir }}/known_hosts'
+      register: git_result
+
+    - assert:
+        that:
+          - git_result is changed
+
+    - name: 10173 - HOSTKEY TESTS | Remove github.com hostkey from known_hosts
+      lineinfile:
+        dest: '{{ remote_tmp_dir }}/known_hosts'
+        regexp: "github.com"
+        state: absent
+
+    - name: 10174 - SETUP (SSH-with-private-key) | debug default remote set.
+      shell: git -C "{{ working_dir }}" remote get-url --all origin
+      register: remote
+    - debug: var=remote
+
+- name: 10174 - delete temporary directory
+  file:
+    path: "{{ remote_tmp_dir }}"
+    state: absent
+  no_log: yes
+
+
 
 - name: 10080 - HTTPS | fail because ssh URL.
   register: result


### PR DESCRIPTION
on awx control node ansible.built.git was succeeding in cloning the repo but git_acp results in :

```
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

to resolve that issue, copied same OS env based approach as used in the ansible/ansible git.py module source at: https://github.com/ansible/ansible/blob/stable-2.10/lib/ansible/modules/git.py#L402

Example usage here:
https://github.com/lj020326/ansible-datacenter/blob/9d6cb87fff09a57dc29fd2d4acdb7b7bd30d0234/tests/test-git-acp.yml#L127
