### PR TITLE
fix: compatibility with pre-commit ansible-lint

### DIFF
--- a/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
@@ -217,7 +217,7 @@ def main():
     # We screenscrape a huge amount of git commands so use C
     # locale anytime we call run_command()
     module.run_command_environ_update = dict(
-        LANG="C", LC_ALL="C", LC_MESSAGES="C", LC_CTYPE="C"
+        LANG="C.UTF-8", LC_ALL="C.UTF-8", LC_MESSAGES="C.UTF-8", LC_CTYPE="C.UTF-8"
     )
 
     if mode == "local":


### PR DESCRIPTION
I have a pre-commit hook that uses ansible-lint, which in turn uses `ansible-config dump` behind the scenes.

This hardcoded locale setting makes it fail with:

    ERROR: Ansible requires the locale encoding to be UTF-8; Detected None.

Thus, setting the UTF-8 mode, which is more similar to what every distro ships these days by default.

@moduon MT-1075