### PR TITLE
feat(pull): allow pulling before pushing

### DIFF
--- a/ansible_collections/lvrfrc87/git_acp/plugins/module_utils/git_actions.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/module_utils/git_actions.py
@@ -185,6 +185,24 @@ fi
         else:
             FailingMessage(self.module, rc, command, output, error)
 
+    def pull(self):
+        """Get git changes from upstream before pushing."""
+        command = [
+            self.git_path,
+            "-C",
+            self.path,
+            "pull",
+            self.module.params["url"],
+            self.module.params["branch"],
+        ] + self.module.params["pull_options"]
+        rc, output, error = self.module.run_command(command)
+        if rc == 0:
+            return {
+                "git_pull": {"stdout": output, "stderr": error},
+                "changed": True,
+            }
+        FailingMessage(self.module, rc, command, output, error)
+
     def push(self):
         """
         Set URL and remote if required. Push changes to remote repo.

--- a/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
@@ -50,6 +50,17 @@ options:
             - Git branch where perform git push.
         type: str
         default: main
+    pull:
+        description:
+            - Perform a git pull before pushing.
+        type: bool
+        default: False
+    pull_options:
+        description:
+            - Options added to the pull command. See C(git pull --help) for available
+              options.
+        type: list
+        default: ['--no-edit']
     push_option:
         description:
             - Git push options. Same as C(git --push-option=option).
@@ -185,6 +196,8 @@ def main():
         token=dict(no_log=True),
         ssh_params=dict(default=None, type="dict", required=False),
         branch=dict(default="main"),
+        pull=dict(default=False, type="bool"),
+        pull_options=dict(default=["--no-edit"], type="list"),
         push_option=dict(default=None, type="str"),
         mode=dict(choices=["ssh", "https", "local"], default="ssh"),
         url=dict(required=True),
@@ -208,6 +221,7 @@ def main():
     )
 
     url = module.params.get("url")
+    pull = module.params.get("pull")
     push_option = module.params.get("push_option")
     mode = module.params.get("mode")
     user_name = module.params.get("user_name")
@@ -265,6 +279,8 @@ def main():
     if changed_files:
         git.add()
         result.update(git.commit())
+        if pull:
+            result.update(git.pull())
         result.update(git.push())
 
     module.exit_json(**result)

--- a/ansible_collections/lvrfrc87/git_acp/tests/integration/targets/git_acp/tasks/main.yml
+++ b/ansible_collections/lvrfrc87/git_acp/tests/integration/targets/git_acp/tasks/main.yml
@@ -456,3 +456,67 @@
   ignore_errors: yes
   loop:
     - "{{ file1 }}"
+
+# Test pull before push
+- name: Create a temporary origin directory
+  register: _pull_src
+  tempfile:
+    state: directory
+
+- name: Create a temporary destination directory
+  register: _pull_dest
+  tempfile:
+    state: directory
+
+- name: Init origin directory
+  shell:
+    chdir: "{{ _pull_src }}"
+    cmd: |
+      git init
+      touch a.txt
+      git add -A
+      git checkout -b main
+      git commit -m 'commit 1'
+
+- name: Clone into destination
+  git:
+    repo: "{{ _pull_src }}"
+    dest: "{{ _pull_dest }}"
+
+- name: Evolve src repo
+  shell:
+    chdir: "{{ _pull_src }}"
+    cmd: |
+      touch b.txt
+      git add -A
+      git commit -m 'commit 2'
+
+- name: Add a file to destination repo
+  file:
+    path: "{{ _pull_dest }}/c.txt"
+    state: file
+
+- name: ACP without pull fails
+  register: _acp
+  ignore_errors: true
+  git_acp:
+    add: [ "c.txt" ]
+    branch: main
+    comment: commit 3
+    mode: local
+    path: "{{ _pull_dest }}"
+    url: "{{ _pull_src }}"
+
+- name: Assert last task failed
+  assert:
+    that: _acp is failed
+
+- name: ACP with pull works
+  git_acp:
+    add: [ "c.txt" ]
+    branch: main
+    comment: commit 3
+    mode: local
+    path: "{{ _pull_dest }}"
+    pull: true
+    url: "{{ _pull_src }}"


### PR DESCRIPTION
When running several tasks in parallel in forks of the same remote, it is normal that one of them fails.

With this new feature, you can instruct the module to pull upstream changes before pushing. It's also easy to use Ansible's loop-until feature to make several attempts until one succeeds.

@moduon MT-1075