### PR TITLE
Fix #63

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+# Ver. 2.1.0
+
+- Add support for `push` option.
+
 # Ver. 2.0.0
 
 - Remove git config argument (the practice of setting parameters in the environmental variables is encouraged)

--- a/ansible_collections/lvrfrc87/git_acp/galaxy.yml
+++ b/ansible_collections/lvrfrc87/git_acp/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: lvrfrc87
 name: git_acp
-version: 2.0.0
+version: 2.1.0
 readme: README.md
 
 authors:

--- a/ansible_collections/lvrfrc87/git_acp/plugins/module_utils/git_actions.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/module_utils/git_actions.py
@@ -114,7 +114,7 @@ fi
         args:
             * module:
                 type: dict()
-                descrition: Ansible basic module utilities and module arguments.
+                description: Ansible basic module utilities and module arguments.
 
         return: null
         """
@@ -138,7 +138,7 @@ fi
         args:
             * module:
                 type: dict()
-                descrition: Ansible basic module utilities and module arguments.
+                description: Ansible basic module utilities and module arguments.
         return:
             * data:
                 type: set()
@@ -166,11 +166,11 @@ fi
         args:
             * module:
                 type: dict()
-                descrition: Ansible basic module utilities and module arguments.
+                description: Ansible basic module utilities and module arguments.
         return:
             * result:
                 type: dict()
-                desription: returned output from git commit command and changed status
+                description: returned output from git commit command and changed status
         """
         comment = self.module.params["comment"]
         command = [self.git_path, "commit", "-m", comment]
@@ -190,17 +190,17 @@ fi
         args:
             * url:
                 type: str()
-                descrition: git url of the git repo.
+                description: git url of the git repo.
             * branch:
                 type: str()
-                descrition: git branch of the git repo.
+                description: git branch of the git repo.
             * pull_options:
                 type: list()
-                desription: pull options added to the pull command.
+                description: pull options added to the pull command.
         return:
             * result:
                 type: dict()
-                descrition: returned output from git pull command.
+                description: returned output from git pull command.
         """
         url = self.module.params["url"]
         branch = self.module.params["branch"]
@@ -226,14 +226,14 @@ fi
         args:
             * path:
                 type: path
-                descrition: git repo local path.
+                description: git repo local path.
             * cmd_push:
                 type: list()
-                descrition: list of commands to perform git push operation.
+                description: list of commands to perform git push operation.
         return:
             * result:
                 type: dict()
-                desription: returned output from git push command and updated changed status.
+                description: returned output from git push command and updated changed status.
         """
         url = self.module.params["url"]
         branch = self.module.params["branch"]

--- a/ansible_collections/lvrfrc87/git_acp/plugins/module_utils/git_actions.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/module_utils/git_actions.py
@@ -172,21 +172,36 @@ fi
                 type: dict()
                 desription: returned output from git commit command and changed status
         """
-        result = dict()
         comment = self.module.params["comment"]
         command = [self.git_path, "commit", "-m", comment]
 
         rc, output, error = self.module.run_command(command, cwd=self.path)
 
         if rc == 0:
-            if output:
-                result.update({"git_commit": {"output": output, "error": error, "changed": True}})
-                return result
-        else:
-            FailingMessage(self.module, rc, command, output, error)
+            return {
+                "git_commit": {"output": output, "error": error, "changed": True}
+            }
+        FailingMessage(self.module, rc, command, output, error)
 
     def pull(self):
-        """Get git changes from upstream before pushing."""
+        """
+        Get git changes from upstream before pushing.
+
+        args:
+            * url:
+                type: str()
+                descrition: git url of the git repo.
+            * branch:
+                type: str()
+                descrition: git branch of the git repo.
+            * pull_options:
+                type: list()
+                desription: pull options added to the pull command.
+        return:
+            * result:
+                type: dict()
+                descrition: returned output from git pull command.
+        """
         url = self.module.params["url"]
         branch = self.module.params["branch"]
         command = [

--- a/ansible_collections/lvrfrc87/git_acp/plugins/module_utils/git_actions.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/module_utils/git_actions.py
@@ -228,12 +228,10 @@ fi
         if push_option:
             command.insert(3, "--push-option={0} ".format(push_option))
 
-        result = dict()
-
         rc, output, error = self.module.run_command(command, cwd=self.path)
 
         if rc == 0:
-            result.update({"git_push": {"output": str(output), "error": str(error), "changed": True}})
-            return result
-        else:
-            FailingMessage(self.module, rc, command, output, error)
+            return {
+                "git_push": {"output": str(output), "error": str(error), "changed": True}
+            }
+        FailingMessage(self.module, rc, command, output, error)

--- a/ansible_collections/lvrfrc87/git_acp/plugins/module_utils/messages.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/module_utils/messages.py
@@ -11,19 +11,19 @@ class ModuleFailure:
         args:
             * module:
                 type: dict()
-                descrition: Ansible basic module utilities and module arguments.
+                description: Ansible basic module utilities and module arguments.
             * rc:
                 type: int()
-                descrition: rc code returned by shell command.
+                description: rc code returned by shell command.
             * command:
                 type: list()
-                descrition: list of string that compose the shell command.
+                description: list of string that compose the shell command.
             * output:
                 type: str()
-                descrition: stdout returned by the shell.
+                description: stdout returned by the shell.
             * error:
                 type: str()
-                descrition: stderreturned by the shell.
+                description: stder returned by the shell.
 
         return: None
         """

--- a/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
@@ -28,15 +28,16 @@ options:
     comment:
         description:
             - Git commit comment. Same as C(git commit -m).
+              Required when using add.
         type: str
-        required: true
     add:
         description:
             - List of files under C(path) to be staged. Same as C(git add .).
               File globs not accepted, such as C(./*) or C(*).
+              Required when using comment.
         type: list
         elements: str
-        default: ["."]
+        default: None
     branch:
         description:
             - Git branch where perform git push.
@@ -54,6 +55,11 @@ options:
         type: list
         elements: str
         default: ['--no-edit']
+    push:
+        description:
+            - Perform a git push.
+        type: bool
+        default: True
     push_option:
         description:
             - Git push options. Same as C(git --push-option=option).
@@ -160,12 +166,13 @@ def main():
     argument_spec = dict(
         path=dict(required=True, type="path"),
         executable=dict(default=None, type="path"),
-        comment=dict(required=True),
-        add=dict(type="list", elements="str", default=["."]),
+        comment=dict(default=None, type="str"),
+        add=dict(default=None, type="list", elements="str"),
         ssh_params=dict(default=None, type="dict", required=False),
         branch=dict(default="main"),
         pull=dict(default=False, type="bool"),
         pull_options=dict(default=["--no-edit"], type="list", elements="str"),
+        push=dict(default=True, type="bool"),
         push_option=dict(default=None, type="str"),
         url=dict(required=True, no_log=True),
     )
@@ -175,7 +182,10 @@ def main():
     )
 
     url = module.params.get("url")
+    comment = module.params.get("comment")
+    add = module.params.get("add")
     pull = module.params.get("pull")
+    push = module.params.get("push")
     ssh_params = module.params.get("ssh_params")
 
     module.run_command_environ_update = dict(
@@ -193,15 +203,32 @@ def main():
                 msg='GitHub does not support "ssh://" URL. Please remove it from url'
             )
 
+    if add and not comment :
+        module.fail_json(
+            msg='Comment is required when using add'
+        )
+
+    if comment and not add :
+        module.fail_json(
+            msg='Add is required when using comment'
+        )
+
+    if not pull and not add and not push:
+        module.fail_json(
+            msg='Missing at least one required param: pull, add, push'
+        )
+
     git = Git(module)
     changed_files = git.status()
 
     if changed_files:
-        git.add()
-        result.update(git.commit())
         if pull:
             result.update(git.pull())
-        result.update(git.push())
+        if add:
+            git.add()
+            result.update(git.commit())
+        if push:
+            result.update(git.push())
         result["changed"] = True
 
     module.exit_json(**result)

--- a/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
@@ -179,10 +179,11 @@ def main():
 
     module = AnsibleModule(
         argument_spec=argument_spec,
+        required_together=[("comment", "add")],
+        required_one_of=[("add", "pull", "push")]
     )
 
     url = module.params.get("url")
-    comment = module.params.get("comment")
     add = module.params.get("add")
     pull = module.params.get("pull")
     push = module.params.get("push")
@@ -202,21 +203,6 @@ def main():
             module.fail_json(
                 msg='GitHub does not support "ssh://" URL. Please remove it from url'
             )
-
-    if add and not comment :
-        module.fail_json(
-            msg='Comment is required when using add'
-        )
-
-    if comment and not add :
-        module.fail_json(
-            msg='Add is required when using comment'
-        )
-
-    if not pull and not add and not push:
-        module.fail_json(
-            msg='Missing at least one required param: pull, add, push'
-        )
 
     git = Git(module)
     changed_files = git.status()

--- a/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
+++ b/ansible_collections/lvrfrc87/git_acp/plugins/modules/git_acp.py
@@ -161,7 +161,7 @@ def main():
     return:
         * result:
             type: dict()
-            desription: returned output from git commands and updated changed status.
+            description: returned output from git commands and updated changed status.
     """
     argument_spec = dict(
         path=dict(required=True, type="path"),

--- a/deployment/master.sh
+++ b/deployment/master.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 cd ../ansible_collections/lvrfrc87/git_acp/ && \
 ansible-galaxy collection build && \
-ansible-galaxy collection install lvrfrc87-git_acp-2.0.0.tar.gz -p ./tests/install/ && \
-ansible-galaxy collection publish ./lvrfrc87-git_acp-2.0.0.tar.gz --token=$GALAXY_TOKEN 
+ansible-galaxy collection install lvrfrc87-git_acp-2.1.0.tar.gz -p ./tests/install/ && \
+ansible-galaxy collection publish ./lvrfrc87-git_acp-2.1.0.tar.gz --token=$GALAXY_TOKEN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-acp-ansible"
-version = "2.0.0"
+version = "2.1.0"
 description = "Git Add/Commit/Push Ansible module."
 authors = ["Federico Olivieri <lvrfrc87@gmail.com"]
 license = "GPL-3.0-only"


### PR DESCRIPTION
Fixes lvrfrc87/git-acp-ansible#63

- Added support for solely pushing 
- Added support for solely adding to the git index
- Bumped version to 2.1.0 
- Updated change log 
- Fixed typos for `description` in doc strings
- Cleaned return method to be consistent
- Used `required_together` and `required_one_of` for dependencies

**Note:** 
This is kind of a breaking change, I have changed `add` to `default=None` from `default=["."]`. So, anyone that is using this feature would have to be aware of this. 
I tried to think of a way to keep this functionality the same, but I think this PR outweighs the the current setting. 
This way we are able to specifically add items to the index without pushing, and likewise, we are able to just execute a `git push` without adding to the index. 
This does **not** mean that the user cannot still use `add` with `push` in one task, it just means if they are expecting the default behaviour, they will just need to pass `add` specifically. 
